### PR TITLE
Remove underline from footer icon

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,7 +63,7 @@
                     {% for link in site.links %}
                       {% if link.Category == Category %}
                         <li class="mb-2">
-                          <a href="{{ link.URL }}{% if link.Username %}/{{link.Username}}{%endif%}" rel="me" alt="Link to my profile on {{Link.Name}}" class="u-url" style="color: {{ link.Text_Color }}"  >
+                          <a href="{{ link.URL }}{% if link.Username %}/{{link.Username}}{%endif%}" rel="me" alt="Link to my profile on {{Link.Name}}" class="u-url {% if link.Type == "emoji" %}no-underline{% endif %}" style="color: {{ link.Text_Color }}"  >
                             {% if link.Type == "emoji" %}
                               <span style="text-decoration: none;">{{link.Icon-Class}} </span>{{link.Name}}
                             {% elsif link.Type == "fontawsome" %}

--- a/_sass/TedsLegacy/_footer.scss
+++ b/_sass/TedsLegacy/_footer.scss
@@ -2,3 +2,7 @@ footer.footer {
   padding-top: 4rem;
   padding-bottom: 4rem;
 }
+
+.no-underline {
+  text-decoration: none;
+}


### PR DESCRIPTION
Remove the underline on the 🤗 icon in the footer.

* Modify `_includes/footer.html` to add a conditional class `no-underline` to the `a` tag containing the `🤗` icon.
* Add a new CSS rule for the `no-underline` class in `_sass/TedsLegacy/_footer.scss` to set `text-decoration` property to `none`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TedTschopp/tedt.org/pull/40?shareId=d0e64389-5c22-443e-a741-5190f2903cec).