### PR TITLE
chore(ci): bump actions/upload-artifact from v6 to v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Upload HTMLProofer log
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: htmlproofer-log
           path: tmp/htmlproofer.txt
@@ -318,7 +318,7 @@ jobs:
 
       - name: Upload Allure report artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: allure-report
           path: |

--- a/.github/workflows/mastodon-feed.yml
+++ b/.github/workflows/mastodon-feed.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload Allure report artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: allure-report-mastodon-feed
           path: |


### PR DESCRIPTION
Bumps the GitHub Actions `actions/upload-artifact` action from v6 to v7 across deploy and mastodon-feed workflows.

**This PR replaces/supersedes #139** which was stale and branch-diverged from current main. This PR is created fresh against current main for clean CI health.

## Changes
- `.github/workflows/deploy.yml`: Updates HTMLProofer log and Allure report uploads
- `.github/workflows/mastodon-feed.yml`: Updates Allure report upload

## Details
All three instances of `actions/upload-artifact@v6` have been updated to `@v7`.