### PR TITLE
fix(traveller): persist drafts and harden row builders

### DIFF
--- a/RPG/Traveller/js/Character-Library.js
+++ b/RPG/Traveller/js/Character-Library.js
@@ -4,6 +4,7 @@
   const LIBRARY_STORAGE_KEY = "traveller-characters-v2";
   const LEGACY_STORAGE_KEY = "traveller-character";
   const LIBRARY_VERSION = 2;
+  const DRAFT_OPTION_ATTRIBUTE = "data-character-draft-option";
   const CHARACTERISTIC_KEYS = [
     "str",
     "dex",
@@ -19,6 +20,42 @@
     "std",
     "wlt",
   ];
+  const DRAFT_DEFAULTS = Object.freeze({
+    trainingSkillName: "",
+    trainingSpecialization: "",
+    trainingWeeksSpent: "1",
+    trainingWeeksTotal: "8",
+    skillSearch: "",
+    specializationField: "",
+    skillLevel: "0",
+    educationType: "",
+    educationYears: "4",
+    educationOutcome: "Graduate",
+    educationBenefits: "",
+    careerName: "",
+    careerAssignment: "",
+    careerPromotions: "0",
+    careerYears: "4",
+    careerRank: "",
+    careerBenefits: "",
+    weaponName: "",
+    weaponTL: "",
+    weaponDamage: "",
+    weaponRange: "",
+    weaponWeight: "",
+    weaponMagazine: "",
+    armorName: "",
+    armorRating: "",
+    armorTL: "",
+    armorRadiation: "",
+    augmentType: "",
+    augmentTL: "",
+    augmentImprovement: "",
+    equipmentName: "",
+    equipmentTL: "",
+    equipmentMass: "",
+    equipmentCost: "",
+  });
 
   let activeCharacterId = null;
   let cleanCharacterSnapshot = null;
@@ -315,6 +352,15 @@
     element.value = value === undefined || value === null ? fallback : value;
   }
 
+  function captureTransientDrafts() {
+    return Object.fromEntries(
+      Object.entries(DRAFT_DEFAULTS).map(([id, fallback]) => [
+        id,
+        valueOf(id, fallback),
+      ])
+    );
+  }
+
   function tableRows(containerId) {
     const container = document.getElementById(containerId);
     return container ? Array.from(container.querySelectorAll("tr")) : [];
@@ -344,6 +390,7 @@
       homeworldUWP: valueOf("homeworldUWP"),
       rads: valueOf("rads", "0"),
       upp: valueOf("upp"),
+      drafts: captureTransientDrafts(),
       preCareerOptions: tableRows("education-container").map((row) => {
         const cells = row.querySelectorAll("td");
         return {
@@ -692,53 +739,95 @@
     });
   }
 
-  function resetTransientInputs() {
-    const defaults = {
-      trainingSkillName: "",
-      trainingSpecialization: "",
-      trainingWeeksSpent: "1",
-      trainingWeeksTotal: "8",
-      skillSearch: "",
-      specializationField: "",
-      skillLevel: "0",
-      educationYears: "4",
-      educationBenefits: "",
-      careerPromotions: "0",
-      careerYears: "4",
-      careerRank: "",
-      careerBenefits: "",
-      weaponName: "",
-      weaponTL: "",
-      weaponDamage: "",
-      weaponRange: "",
-      weaponWeight: "",
-      weaponMagazine: "",
-      armorName: "",
-      armorRating: "",
-      armorTL: "",
-      armorRadiation: "",
-      augmentType: "",
-      augmentTL: "",
-      augmentImprovement: "",
-      equipmentName: "",
-      equipmentTL: "",
-      equipmentMass: "",
-      equipmentCost: "",
-    };
+  function draftValue(drafts, id) {
+    const value = drafts[id];
+    return value === undefined || value === null ? DRAFT_DEFAULTS[id] : value;
+  }
 
-    Object.entries(defaults).forEach(([id, value]) => setValue(id, value));
-    ["educationType", "educationOutcome", "careerName", "careerAssignment"].forEach(
-      (id) => {
-        const select = document.getElementById(id);
-        if (select) select.selectedIndex = 0;
+  function setSelectValue(id, value, fallback = "") {
+    const select = document.getElementById(id);
+    if (!select) return;
+
+    Array.from(select.options).forEach((option) => {
+      if (option.hasAttribute(DRAFT_OPTION_ATTRIBUTE)) option.remove();
+    });
+
+    const selectedValue = String(
+      value === undefined || value === null ? fallback : value
+    );
+    if (
+      selectedValue &&
+      !Array.from(select.options).some((option) => option.value === selectedValue)
+    ) {
+      const option = document.createElement("option");
+      option.value = selectedValue;
+      option.textContent = selectedValue;
+      option.setAttribute(DRAFT_OPTION_ATTRIBUTE, "true");
+      select.add(option);
+    }
+    select.value = selectedValue;
+  }
+
+  function rebuildCareerAssignmentOptions(careerName) {
+    setSelectValue("careerName", careerName, DRAFT_DEFAULTS.careerName);
+
+    const assignment = document.getElementById("careerAssignment");
+    if (!assignment) return;
+
+    if (typeof window.updateAssignments === "function") {
+      window.updateAssignments();
+      return;
+    }
+
+    const prompt = document.createElement("option");
+    prompt.value = "";
+    prompt.textContent = "Select Assignment...";
+    assignment.replaceChildren(prompt);
+  }
+
+  function resetTransientInputs(savedDrafts) {
+    const drafts = isRecord(savedDrafts) ? savedDrafts : {};
+
+    Object.keys(DRAFT_DEFAULTS).forEach((id) => {
+      if (
+        id === "educationType" ||
+        id === "educationOutcome" ||
+        id === "careerName" ||
+        id === "careerAssignment" ||
+        id === "careerRank"
+      ) {
+        return;
       }
+      setValue(id, draftValue(drafts, id), DRAFT_DEFAULTS[id]);
+    });
+
+    setSelectValue(
+      "educationType",
+      draftValue(drafts, "educationType"),
+      DRAFT_DEFAULTS.educationType
+    );
+    setSelectValue(
+      "educationOutcome",
+      draftValue(drafts, "educationOutcome"),
+      DRAFT_DEFAULTS.educationOutcome
+    );
+    rebuildCareerAssignmentOptions(draftValue(drafts, "careerName"));
+    setSelectValue(
+      "careerAssignment",
+      draftValue(drafts, "careerAssignment"),
+      DRAFT_DEFAULTS.careerAssignment
+    );
+    setValue(
+      "careerRank",
+      draftValue(drafts, "careerRank"),
+      DRAFT_DEFAULTS.careerRank
     );
   }
 
   function applyCharacterData(character) {
     const data = isRecord(character) ? character : {};
     clearDynamicSections();
-    resetTransientInputs();
+    resetTransientInputs(data.drafts);
 
     setValue("charName", data.charName);
     setValue("species", data.species, "Human");
@@ -976,6 +1065,10 @@
       !isRecord(character.characteristics)
     ) {
       throw new Error("The characteristics section is not valid character data.");
+    }
+
+    if (character.drafts !== undefined && !isRecord(character.drafts)) {
+      throw new Error("The drafts section is not valid character data.");
     }
 
     return character;

--- a/RPG/Traveller/js/Character-Sheet.js
+++ b/RPG/Traveller/js/Character-Sheet.js
@@ -13,6 +13,16 @@ function getCareerDiscipline(careerName) {
   }
 }
 
+// Escape user-controlled values before inserting them into HTML text or quoted attributes.
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 // Define core functions before they are used
 
 // Update the DM (Dice Modifier) based on characteristic value
@@ -282,6 +292,7 @@ function updateExistingSkill(skillName, specialization, level) {
     ) {
       const input = skillItems[i].querySelector("input");
       input.value = level;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
       return true;
     }
   }
@@ -309,17 +320,17 @@ function addSingleSkill(skillName, specialization, skillLevel) {
 
   // Store both skill name and specialization separately for data handling
   skillDiv.innerHTML = `
-                <span class="skill-name" data-skill="${skillName}" data-specialization="${
-    specialization || ""
+                <span class="skill-name" data-skill="${escapeHtml(skillName)}" data-specialization="${
+    escapeHtml(specialization || "")
   }">
-                    ${skillName}${
+                    ${escapeHtml(skillName)}${
     specialization
-      ? ` <span class="skill-specialization">(${specialization})</span>`
+      ? ` <span class="skill-specialization">(${escapeHtml(specialization)})</span>`
       : ""
   }
                 </span>
                 <div class="d-flex align-items-center">
-                    <input type="number" class="form-control form-control-sm mx-2" value="${skillLevel}" min="0" style="width: 60px;">
+                    <input type="number" class="form-control form-control-sm mx-2" value="${escapeHtml(skillLevel)}" min="0" style="width: 60px;" aria-label="${escapeHtml(skillName || "Skill")} level">
                     <button class="btn btn-remove no-print" onclick="this.parentElement.parentElement.remove()">×</button>
                 </div>
             `;
@@ -434,10 +445,10 @@ function addEducation() {
   const educationContainer = document.getElementById("education-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-                <td data-type="${educationType}">${educationType}</td>
-                <td data-years="${educationYears}">${educationYears}</td>
-                <td data-outcome="${educationOutcome}">${educationOutcome}</td>
-                <td data-benefits="${educationBenefits}">${educationBenefits}</td>
+                <td data-type="${escapeHtml(educationType)}">${escapeHtml(educationType)}</td>
+                <td data-years="${escapeHtml(educationYears)}">${escapeHtml(educationYears)}</td>
+                <td data-outcome="${escapeHtml(educationOutcome)}">${escapeHtml(educationOutcome)}</td>
+                <td data-benefits="${escapeHtml(educationBenefits)}">${escapeHtml(educationBenefits)}</td>
                 <td class="no-print">
                     <button class="btn btn-remove" onclick="this.closest('tr').remove(); updateEducationButtons(); updateTotalYears();">×</button>
                 </td>
@@ -1162,12 +1173,12 @@ function addCareer() {
   const careersContainer = document.getElementById("careers-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-                <td data-career="${careerName}">${careerName}</td>
-                <td data-assignment="${careerAssignment}">${careerAssignment}</td>
-                <td data-promotions="${careerPromotions}">${careerPromotions}</td>
-                <td data-years="${careerYears}">${careerYears}</td>
-                <td data-rank="${careerRank}">${careerRank}</td>
-                <td data-benefits="${careerBenefits}">${careerBenefits}</td>
+                <td data-career="${escapeHtml(careerName)}">${escapeHtml(careerName)}</td>
+                <td data-assignment="${escapeHtml(careerAssignment)}">${escapeHtml(careerAssignment)}</td>
+                <td data-promotions="${escapeHtml(careerPromotions)}">${escapeHtml(careerPromotions)}</td>
+                <td data-years="${escapeHtml(careerYears)}">${escapeHtml(careerYears)}</td>
+                <td data-rank="${escapeHtml(careerRank)}">${escapeHtml(careerRank)}</td>
+                <td data-benefits="${escapeHtml(careerBenefits)}">${escapeHtml(careerBenefits)}</td>
                 <td class="no-print">
                     <button class="btn btn-remove" onclick="this.closest('tr').remove(); updateTotalYears();">×</button>
                 </td>
@@ -1285,13 +1296,13 @@ function addWeapon() {
   const weaponsContainer = document.getElementById("weapons-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-                <td>${weaponName}</td>
-                <td>${weaponTL || "-"}</td>
-                <td><input type="text" class="form-control form-control-sm" placeholder="Skill"></td>
-                <td>${weaponDamage || "-"}</td>
-                <td>${weaponRange || "-"}</td>
-                <td>${weaponWeight || "-"}</td>
-                <td>${weaponMagazine || "-"}</td>
+                <td>${escapeHtml(weaponName)}</td>
+                <td>${escapeHtml(weaponTL || "-")}</td>
+                <td><input type="text" class="form-control form-control-sm" placeholder="Skill" aria-label="${escapeHtml(weaponName || "Weapon")} skill"></td>
+                <td>${escapeHtml(weaponDamage || "-")}</td>
+                <td>${escapeHtml(weaponRange || "-")}</td>
+                <td>${escapeHtml(weaponWeight || "-")}</td>
+                <td>${escapeHtml(weaponMagazine || "-")}</td>
                 <td class="no-print">
                     <button class="btn btn-remove" onclick="this.closest('tr').remove()">×</button>
                 </td>
@@ -1323,10 +1334,10 @@ function addArmor() {
   const armorContainer = document.getElementById("armor-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-                <td>${armorName}</td>
-                <td>${armorRating || "0"}</td>
-                <td>${armorTL || "-"}</td>
-                <td>${armorRadiation || "-"}</td>
+                <td>${escapeHtml(armorName)}</td>
+                <td>${escapeHtml(armorRating || "0")}</td>
+                <td>${escapeHtml(armorTL || "-")}</td>
+                <td>${escapeHtml(armorRadiation || "-")}</td>
                 <td class="no-print">
                     <button class="btn btn-remove" onclick="this.closest('tr').remove()">×</button>
                 </td>
@@ -1356,10 +1367,10 @@ function addEquipment() {
   const equipmentContainer = document.getElementById("equipment-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-                <td>${equipmentName}</td>
-                <td>${equipmentTL || "-"}</td>
-                <td>${equipmentMass || "0"}</td>
-                <td>${equipmentCost || "0"}</td>
+                <td>${escapeHtml(equipmentName)}</td>
+                <td>${escapeHtml(equipmentTL || "-")}</td>
+                <td>${escapeHtml(equipmentMass || "0")}</td>
+                <td>${escapeHtml(equipmentCost || "0")}</td>
                 <td class="no-print">
                     <button class="btn btn-remove" onclick="this.closest('tr').remove()">×</button>
                 </td>
@@ -1713,10 +1724,10 @@ function addTrainingSkill() {
   const trainingContainer = document.getElementById("training-skills-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-    <td data-skill="${skillName}">${skillName}</td>
-    <td data-specialization="${specialization}">${specialization || "-"}</td>
-    <td data-weeks-spent="${weeksSpent}">${weeksSpent}</td>
-    <td data-weeks-total="${weeksTotal}">${weeksTotal}</td>
+    <td data-skill="${escapeHtml(skillName)}">${escapeHtml(skillName)}</td>
+    <td data-specialization="${escapeHtml(specialization)}">${escapeHtml(specialization || "-")}</td>
+    <td data-weeks-spent="${escapeHtml(weeksSpent)}">${escapeHtml(weeksSpent)}</td>
+    <td data-weeks-total="${escapeHtml(weeksTotal)}">${escapeHtml(weeksTotal)}</td>
     <td class="no-print">
       <button class="btn btn-remove" onclick="this.closest('tr').remove()">×</button>
       <button class="btn btn-secondary btn-sm ml-2" onclick="completeTraining(this)">Complete</button>
@@ -2548,9 +2559,9 @@ function addAugment() {
   const augmentsContainer = document.getElementById("augments-container");
   const row = document.createElement("tr");
   row.innerHTML = `
-    <td>${augmentType}</td>
-    <td>${augmentTL || "-"}</td>
-    <td>${augmentImprovement || "-"}</td>
+    <td>${escapeHtml(augmentType)}</td>
+    <td>${escapeHtml(augmentTL || "-")}</td>
+    <td>${escapeHtml(augmentImprovement || "-")}</td>
     <td class="no-print">
       <button class="btn btn-remove" onclick="this.closest('tr').remove()">×</button>
     </td>


### PR DESCRIPTION
## Summary

- save and restore all 34 unfinished Add-form draft fields per character
- mark programmatic skill-level updates as unsaved
- preserve compatible custom select values without leaking them between characters
- add accessible names to newly created skill and weapon inputs
- escape user-controlled draft values before legacy row-builder HTML insertion

## Why

The multi-character audit confirmed that committed character data round-tripped correctly, but unfinished row drafts could be discarded and one skill update path could remain falsely clean. Persisting drafts also exposed a legacy HTML interpolation path, which this change hardens before release.

## Testing

- 629 persistence, isolation, import, and legacy-storage assertions
- 141 adversarial encoding and select-isolation assertions
- isolated browser save/new/load round trip for all 34 draft controls
- browser dirty-state and dynamic accessible-name checks
- scoped axe audit: zero violations in changed dynamic containers
- `node --check` for both JavaScript files
- `bundle exec jekyll build`
- rendered source/output byte comparison
- scoped HTMLProofer

## Impact

No layout or SEO changes. Existing draftless saves and original direct-object exports remain compatible. The legacy `traveller-character` key remains read-only.
